### PR TITLE
Add support for passthru of sign argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ sudo: false
 os: linux
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
   - "4"
   - "5"
   - "6"
   - "7"
+  - "8"
 env:
   matrix:
     - TEST_SUITE=unit

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ var bitcoin = require('bitcoinjs-lib') // v3.x.x
 var bitcoinMessage = require('bitcoinjs-message')
 ```
 
-> sign(message, privateKey, compressed[, network.messagePrefix, segwitType])
+> sign(message, privateKey, compressed[, network.messagePrefix, sigOptions])
+> - If you pass the sigOptions arg instead of messagePrefix it will dynamically replace.
+> - sigOptions contains two attributes
+>   - `segwitType` should be one of `'p2sh(p2wpkh)'` or `'p2wpkh'`
+>   - `extraEntropy` will be used to create non-deterministic signatures using the RFC6979 extra entropy parameter. R value reuse is not an issue.
 
 Sign a Bitcoin message
 ``` javascript
@@ -32,7 +36,7 @@ var keyPair = bitcoin.ECPair.fromWIF('5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j29
 var privateKey = keyPair.privateKey
 var message = 'This is an example of a signed message.'
 
-var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, null, null, {data: randomBytes(32)})
+var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, { extraEntropy: randomBytes(32) })
 console.log(signature.toString('base64'))
 // => different (but valid) signature each time
 ```
@@ -40,12 +44,12 @@ console.log(signature.toString('base64'))
 Sign a Bitcoin message (with segwit addresses)
 ``` javascript
 // P2SH(P2WPKH) address 'p2sh(p2wpkh)'
-var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, null, 'p2sh(p2wpkh)')
+var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, { segwitType: 'p2sh(p2wpkh)' })
 console.log(signature.toString('base64'))
 // => 'I9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk='
 
 // P2WPKH address 'p2wpkh'
-var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, null, 'p2wpkh')
+var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, { segwitType: 'p2wpkh' })
 console.log(signature.toString('base64'))
 // => 'J9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk='
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ console.log(signature.toString('base64'))
 // => 'G9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk='
 ```
 
+To produce non-deterministic signatures you can pass an extra option to sign()
+``` javascript
+var {randomBytes} = require('crypto')
+var keyPair = bitcoin.ECPair.fromWIF('5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss')
+var privateKey = keyPair.d.toBuffer(32)
+var message = 'This is an example of a signed message.'
+
+var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed, {data: randomBytes(32)})
+console.log(signature.toString('base64'))
+// => different (but valid) signature each time
+```
+
 > verify(message, address, signature[, network.messagePrefix])
 
 Verify a Bitcoin message

--- a/index.js
+++ b/index.js
@@ -75,9 +75,13 @@ function sign (
   privateKey,
   compressed,
   messagePrefix,
-  segwitType,
   sigOptions
 ) {
+  if (typeof messagePrefix === 'object' && sigOptions === undefined) {
+    sigOptions = messagePrefix
+    messagePrefix = undefined
+  }
+  let { segwitType, extraEntropy } = sigOptions || {}
   if (
     segwitType &&
     (typeof segwitType === 'string' || segwitType instanceof String)
@@ -98,7 +102,7 @@ function sign (
     )
   }
   const hash = magicHash(message, messagePrefix)
-  const sigObj = secp256k1.sign(hash, privateKey, sigOptions)
+  const sigObj = secp256k1.sign(hash, privateKey, { data: extraEntropy })
   return encodeSignature(
     sigObj.signature,
     sigObj.recovery,

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function magicHash (message, messagePrefix) {
 }
 
 function sign (message, privateKey, compressed, messagePrefix, sigOptions) {
-  if ((typeof messagePrefix) === 'object' && sigOptions === undefined) {
+  if (typeof messagePrefix === 'object' && sigOptions === undefined) {
     sigOptions = messagePrefix
     messagePrefix = undefined
   }

--- a/index.js
+++ b/index.js
@@ -44,9 +44,13 @@ function magicHash (message, messagePrefix) {
   return hash256(buffer)
 }
 
-function sign (message, privateKey, compressed, messagePrefix) {
+function sign (message, privateKey, compressed, messagePrefix, sigOptions) {
+  if ((typeof messagePrefix) === 'object' && sigOptions === undefined) {
+    sigOptions = messagePrefix
+    messagePrefix = undefined
+  }
   var hash = magicHash(message, messagePrefix)
-  var sigObj = secp256k1.sign(hash, privateKey)
+  var sigObj = secp256k1.sign(hash, privateKey, sigOptions)
   return encodeSignature(sigObj.signature, sigObj.recovery, compressed)
 }
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "devDependencies": {
     "bigi": "^1.4.1",
     "bitcoinjs-lib": "^3.2.0",
-    "nyc": "^11.2.1",
-    "standard": "*",
+    "nyc": "^14.1.1",
+    "standard": "^12.0.1",
     "tape": "^4.5.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bs58check": "^2.0.2",
+    "bs58check": "^2.1.2",
     "buffer-equals": "^1.0.3",
     "create-hash": "^1.1.2",
     "secp256k1": "^3.0.1",

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -144,5 +144,22 @@
         "signature": "G8JawPtQOrybrSP1WHQnQPr67B9S3qrxBrl1mlzoTJOSHEpmnF7D3+t+LX0Xei9J20B5AIdPbeL3AaTBZ4N3bY0="
       }
     ]
-  }
+  },
+  "randomSig": [
+    {
+      "description": "check that signatures extra data argument is passed correctly",
+      "wif": "5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss",
+      "message": "vires is numeris",
+      "signatures": [
+        {
+          "sigData": "1Vc1E/K7DPDACw64fCoeFFKC2+W4KwLxnycBcTCoqsU=",
+          "signature": "HMzQ6VfHpu+frKdemK6xcxpJaCLp0xNlpAzsAGPWZhMKE3i1nDLveuFOjPZ4vk20Y7wP4rJ6rJWvCNJ0EZRoGZ0="
+        },
+        {
+          "sigData": "eMC2QibQm2Rti7rDulocpIPEEKB5DJEzMPyCRW+1Qwc=",
+          "signature": "G9b9KZWgwjh3Ye5z3p+JMNrgZFaMl6QZVwYHuOQcKUSEXYh8a8lrV2/AFlc31+O181Xrj2iZ62YFFgZDl1GsDh0="
+        }
+      ]
+    }
+  ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -64,3 +64,18 @@ fixtures.invalid.verify.forEach(function (f) {
     t.end()
   })
 })
+
+fixtures.randomSig.forEach(function (f) {
+  test(f.description, function (t) {
+    var keyPair = bitcoin.ECPair.fromWIF(f.wif)
+    var privateKey = keyPair.d.toBuffer(32)
+    var address = keyPair.getAddress()
+    f.signatures.forEach(function (s) {
+      var signature = message.sign(f.message, privateKey, keyPair.compressed, undefined, {data: Buffer.from(s.sigData, 'base64')})
+      t.true(message.verify(f.message, address, signature))
+      signature = message.sign(f.message, privateKey, keyPair.compressed, {data: Buffer.from(s.sigData, 'base64')})
+      t.true(message.verify(f.message, address, signature))
+    })
+    t.end()
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,34 @@
-var test = require('tape').test
-var bitcoin = require('bitcoinjs-lib')
-var BigInteger = require('bigi')
-var message = require('../')
+const test = require('tape').test
+const bitcoin = require('bitcoinjs-lib')
+const BigInteger = require('bigi')
+const message = require('../')
 
-var fixtures = require('./fixtures.json')
+const fixtures = require('./fixtures.json')
 
 function getMessagePrefix (networkName) {
   return fixtures.networks[networkName]
 }
 
-fixtures.valid.magicHash.forEach(function (f) {
-  test('produces the magicHash for "' + f.message + '" (' + f.network + ')', function (t) {
-    var actual = message.magicHash(f.message, getMessagePrefix(f.network))
-    t.same(actual.toString('hex'), f.magicHash)
-    t.end()
-  })
+fixtures.valid.magicHash.forEach(f => {
+  test(
+    'produces the magicHash for "' + f.message + '" (' + f.network + ')',
+    t => {
+      const actual = message.magicHash(f.message, getMessagePrefix(f.network))
+      t.same(actual.toString('hex'), f.magicHash)
+      t.end()
+    }
+  )
 })
 
-fixtures.valid.sign.forEach(function (f) {
-  test('sign: ' + f.description, function (t) {
-    var pk = new bitcoin.ECPair(new BigInteger(f.d)).d.toBuffer(32)
-    var signature = message.sign(f.message, pk, false, getMessagePrefix(f.network))
+fixtures.valid.sign.forEach(f => {
+  test('sign: ' + f.description, t => {
+    const pk = new bitcoin.ECPair(new BigInteger(f.d)).d.toBuffer(32)
+    let signature = message.sign(
+      f.message,
+      pk,
+      false,
+      getMessagePrefix(f.network)
+    )
     t.same(signature.toString('base64'), f.signature)
 
     if (f.compressed) {
@@ -30,11 +38,23 @@ fixtures.valid.sign.forEach(function (f) {
 
     if (f.segwit) {
       if (f.segwit.P2SH_P2WPKH) {
-        signature = message.sign(f.message, pk, true, getMessagePrefix(f.network), 'p2sh(p2wpkh)')
+        signature = message.sign(
+          f.message,
+          pk,
+          true,
+          getMessagePrefix(f.network),
+          'p2sh(p2wpkh)'
+        )
         t.same(signature.toString('base64'), f.segwit.P2SH_P2WPKH.signature)
       }
       if (f.segwit.P2WPKH) {
-        signature = message.sign(f.message, pk, true, getMessagePrefix(f.network), 'p2wpkh')
+        signature = message.sign(
+          f.message,
+          pk,
+          true,
+          getMessagePrefix(f.network),
+          'p2wpkh'
+        )
         t.same(signature.toString('base64'), f.segwit.P2WPKH.signature)
       }
     }
@@ -43,57 +63,100 @@ fixtures.valid.sign.forEach(function (f) {
   })
 })
 
-fixtures.valid.verify.forEach(function (f) {
-  test('verifies a valid signature for "' + f.message + '" (' + f.network + ')', function (t) {
-    t.true(message.verify(f.message, f.address, f.signature, getMessagePrefix(f.network)))
+fixtures.valid.verify.forEach(f => {
+  test(
+    'verifies a valid signature for "' + f.message + '" (' + f.network + ')',
+    t => {
+      t.true(
+        message.verify(
+          f.message,
+          f.address,
+          f.signature,
+          getMessagePrefix(f.network)
+        )
+      )
 
-    if (f.network === 'bitcoin') {
-      // defaults to bitcoin network
-      t.true(message.verify(f.message, f.address, f.signature))
-    }
-
-    if (f.compressed) {
-      t.true(message.verify(f.message, f.compressed.address, f.compressed.signature, getMessagePrefix(f.network)))
-    }
-
-    if (f.segwit) {
-      if (f.segwit.P2SH_P2WPKH) {
-        t.true(message.verify(f.message, f.segwit.P2SH_P2WPKH.address, f.segwit.P2SH_P2WPKH.signature, getMessagePrefix(f.network)))
+      if (f.network === 'bitcoin') {
+        // defaults to bitcoin network
+        t.true(message.verify(f.message, f.address, f.signature))
       }
-      if (f.segwit.P2WPKH) {
-        t.true(message.verify(f.message, f.segwit.P2WPKH.address, f.segwit.P2WPKH.signature, getMessagePrefix(f.network)))
-      }
-    }
 
-    t.end()
-  })
+      if (f.compressed) {
+        t.true(
+          message.verify(
+            f.message,
+            f.compressed.address,
+            f.compressed.signature,
+            getMessagePrefix(f.network)
+          )
+        )
+      }
+
+      if (f.segwit) {
+        if (f.segwit.P2SH_P2WPKH) {
+          t.true(
+            message.verify(
+              f.message,
+              f.segwit.P2SH_P2WPKH.address,
+              f.segwit.P2SH_P2WPKH.signature,
+              getMessagePrefix(f.network)
+            )
+          )
+        }
+        if (f.segwit.P2WPKH) {
+          t.true(
+            message.verify(
+              f.message,
+              f.segwit.P2WPKH.address,
+              f.segwit.P2WPKH.signature,
+              getMessagePrefix(f.network)
+            )
+          )
+        }
+      }
+
+      t.end()
+    }
+  )
 })
 
-fixtures.invalid.signature.forEach(function (f) {
-  test('decode signature: throws on ' + f.hex, function (t) {
-    t.throws(function () {
+fixtures.invalid.signature.forEach(f => {
+  test('decode signature: throws on ' + f.hex, t => {
+    t.throws(() => {
       message.verify(null, null, Buffer.from(f.hex, 'hex'), null)
     }, new RegExp('^Error: ' + f.exception + '$'))
     t.end()
   })
 })
 
-fixtures.invalid.verify.forEach(function (f) {
-  test(f.description, function (t) {
-    t.false(message.verify(f.message, f.address, f.signature, getMessagePrefix('bitcoin')))
+fixtures.invalid.verify.forEach(f => {
+  test(f.description, t => {
+    t.false(
+      message.verify(
+        f.message,
+        f.address,
+        f.signature,
+        getMessagePrefix('bitcoin')
+      )
+    )
     t.end()
   })
 })
 
-fixtures.randomSig.forEach(function (f) {
-  test(f.description, function (t) {
-    var keyPair = bitcoin.ECPair.fromWIF(f.wif)
-    var privateKey = keyPair.d.toBuffer(32)
-    var address = keyPair.getAddress()
-    f.signatures.forEach(function (s) {
-      var signature = message.sign(f.message, privateKey, keyPair.compressed, undefined, {data: Buffer.from(s.sigData, 'base64')})
-      t.true(message.verify(f.message, address, signature))
-      signature = message.sign(f.message, privateKey, keyPair.compressed, {data: Buffer.from(s.sigData, 'base64')})
+fixtures.randomSig.forEach(f => {
+  test(f.description, t => {
+    const keyPair = bitcoin.ECPair.fromWIF(f.wif)
+    const privateKey = keyPair.d.toBuffer(32)
+    const address = keyPair.getAddress()
+    f.signatures.forEach(s => {
+      const signature = message.sign(
+        f.message,
+        privateKey,
+        keyPair.compressed,
+        undefined,
+        undefined,
+        { data: Buffer.from(s.sigData, 'base64') }
+      )
       t.true(message.verify(f.message, address, signature))
     })
     t.end()

--- a/test/index.js
+++ b/test/index.js
@@ -43,7 +43,7 @@ fixtures.valid.sign.forEach(f => {
           pk,
           true,
           getMessagePrefix(f.network),
-          'p2sh(p2wpkh)'
+          { segwitType: 'p2sh(p2wpkh)' }
         )
         t.same(signature.toString('base64'), f.segwit.P2SH_P2WPKH.signature)
       }
@@ -53,7 +53,7 @@ fixtures.valid.sign.forEach(f => {
           pk,
           true,
           getMessagePrefix(f.network),
-          'p2wpkh'
+          { segwitType: 'p2wpkh' }
         )
         t.same(signature.toString('base64'), f.segwit.P2WPKH.signature)
       }
@@ -153,9 +153,7 @@ fixtures.randomSig.forEach(f => {
         f.message,
         privateKey,
         keyPair.compressed,
-        undefined,
-        undefined,
-        { data: Buffer.from(s.sigData, 'base64') }
+        { extraEntropy: Buffer.from(s.sigData, 'base64') }
       )
       t.true(message.verify(f.message, address, signature))
     })


### PR DESCRIPTION
These changes adds an extra parameter to sign() to control the signature behavior. In particular it allows the production of non-deterministic signatures by using randomness.

This does not break compatibility (if the argument is missing previous behavior is maintained).