### PR TITLE
Fix error of 'd' not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dogecoin-message-signer
+# bitcoinjs-message
 [![NPM Package](https://img.shields.io/npm/v/bitcoinjs-message.svg?style=flat-square)](https://www.npmjs.org/package/bitcoinjs-message)
 [![Build Status](https://img.shields.io/travis/bitcoinjs/bitcoinjs-message.svg?branch=master&style=flat-square)](https://travis-ci.org/bitcoinjs/bitcoinjs-message)
 [![Dependency status](https://img.shields.io/david/bitcoinjs/bitcoinjs-message.svg?style=flat-square)](https://david-dm.org/bitcoinjs/bitcoinjs-message#info=dependencies)
@@ -8,42 +8,32 @@
 ## Examples
 
 ``` javascript
-var cryptocoin = require('bitcoinjs-lib') // v3.x.x
-var cryptocoinMessage = require('bitcoinjs-message')
+var bitcoin = require('bitcoinjs-lib') // v3.x.x
+var bitcoinMessage = require('bitcoinjs-message')
 ```
 
 > sign(message, privateKey, compressed[, network.messagePrefix])
 
-Sign a Dogecoin message
+Sign a Bitcoin message
 ``` javascript
+var keyPair = bitcoin.ECPair.fromWIF('5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss')
+var privateKey = keyPair.__d
+var message = 'This is an example of a signed message.'
 
-var dogecoinNetwork =   {
-    messagePrefix: '\x19Dogecoin Signed Message:\n',
-    bip32: {
-      public: 0x02facafd,
-      private: 0x02fac398
-    },
-    pubKeyHash: 0x1e,
-    scriptHash: 0x16,
-    wif: 0x9e
-  }
-
-var keyPair = cryptocoin.ECPair.fromWIF('6Kq3vjVfdF5TwFBZ9r1yZAPYtKSxotvm45EXjxkwR5p3aNb4DKX', dogecoinNetwork);
-var privateKey = keyPair.__d;
-var message = 'This is an example of a dogecoin signed message.';
-
-var signature = cryptocoinMessage.sign(message, privateKey, keyPair.compressed);
-console.log(signature.toString('base64'));
-// => HCo9HyAmfVmLnEfTvsB+kwr+j9LbWV1lOwPKi2OpOaOBOxkOnUTXjx5o2cURRPe88vYHa4AKyVjJLR9zoEB90Rs=
+var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed)
+console.log(signature.toString('base64'))
+// => 'G9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk='
 ```
 
-> verify(message, address, signature[, network.messagePrefix]);
+> verify(message, address, signature[, network.messagePrefix])
 
-Verify a Dogecoin message
+Verify a Bitcoin message
 ``` javascript
-var address = 'DTAbymNwBLCHiCcwD2oToaKX6ZVgUQ2b2g';
+var address = '1HZwkjkeaoZfTSaJxDw6aKkxp45agDiEzN'
+var signature = 'HJLQlDWLyb1Ef8bQKEISzFbDAKctIlaqOpGbrk3YVtRsjmC61lpE5ErkPRUFtDKtx98vHFGUWlFhsh3DiW6N0rE'
+var message = 'This is an example of a signed message.'
 
-console.log(cryptocoinMessage.verify(message, address, signature));
+console.log(bitcoinMessage.verify(message, address, signature))
 // => true
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ console.log(signature.toString('base64'))
 Verify a Bitcoin message
 ``` javascript
 var address = '1HZwkjkeaoZfTSaJxDw6aKkxp45agDiEzN'
-var signature = 'HJLQlDWLyb1Ef8bQKEISzFbDAKctIlaqOpGbrk3YVtRsjmC61lpE5ErkPRUFtDKtx98vHFGUWlFhsh3DiW6N0rE'
-var message = 'This is an example of a signed message.'
 
 console.log(bitcoinMessage.verify(message, address, signature))
 // => true

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var bitcoinMessage = require('bitcoinjs-message')
 Sign a Bitcoin message
 ``` javascript
 var keyPair = bitcoin.ECPair.fromWIF('5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss')
-var privateKey = keyPair.__d
+var privateKey = keyPair.privateKey
 var message = 'This is an example of a signed message.'
 
 var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bitcoinjs-message
+# dogecoin-message-signer
 [![NPM Package](https://img.shields.io/npm/v/bitcoinjs-message.svg?style=flat-square)](https://www.npmjs.org/package/bitcoinjs-message)
 [![Build Status](https://img.shields.io/travis/bitcoinjs/bitcoinjs-message.svg?branch=master&style=flat-square)](https://travis-ci.org/bitcoinjs/bitcoinjs-message)
 [![Dependency status](https://img.shields.io/david/bitcoinjs/bitcoinjs-message.svg?style=flat-square)](https://david-dm.org/bitcoinjs/bitcoinjs-message#info=dependencies)
@@ -8,8 +8,8 @@
 ## Examples
 
 ``` javascript
-var bitcoin = require('bitcoinjs-lib') // v3.x.x
-var bitcoinMessage = require('bitcoinjs-message')
+var cryptocoin = require('bitcoinjs-lib') // v3.x.x
+var cryptocoinMessage = require('bitcoinjs-message')
 ```
 
 > sign(message, privateKey, compressed[, network.messagePrefix])
@@ -28,11 +28,11 @@ var dogecoinNetwork =   {
     wif: 0x9e
   }
 
-var keyPair = bitcoin.ECPair.fromWIF('6Kq3vjVfdF5TwFBZ9r1yZAPYtKSxotvm45EXjxkwR5p3aNb4DKX', dogecoinNetwork);
+var keyPair = cryptocoin.ECPair.fromWIF('6Kq3vjVfdF5TwFBZ9r1yZAPYtKSxotvm45EXjxkwR5p3aNb4DKX', dogecoinNetwork);
 var privateKey = keyPair.__d;
 var message = 'This is an example of a dogecoin signed message.';
 
-var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed);
+var signature = cryptocoinMessage.sign(message, privateKey, keyPair.compressed);
 console.log(signature.toString('base64'));
 // => HCo9HyAmfVmLnEfTvsB+kwr+j9LbWV1lOwPKi2OpOaOBOxkOnUTXjx5o2cURRPe88vYHa4AKyVjJLR9zoEB90Rs=
 ```
@@ -43,7 +43,7 @@ Verify a Dogecoin message
 ``` javascript
 var address = 'DTAbymNwBLCHiCcwD2oToaKX6ZVgUQ2b2g';
 
-console.log(bitcoinMessage.verify(message, address, signature));
+console.log(cryptocoinMessage.verify(message, address, signature));
 // => true
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,26 +14,36 @@ var bitcoinMessage = require('bitcoinjs-message')
 
 > sign(message, privateKey, compressed[, network.messagePrefix])
 
-Sign a Bitcoin message
+Sign a Dogecoin message
 ``` javascript
-var keyPair = bitcoin.ECPair.fromWIF('5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss')
-var privateKey = keyPair.d.toBuffer(32)
-var message = 'This is an example of a signed message.'
 
-var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed)
-console.log(signature.toString('base64'))
-// => 'G9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk='
+var dogecoinNetwork =   {
+    messagePrefix: '\x19Dogecoin Signed Message:\n',
+    bip32: {
+      public: 0x02facafd,
+      private: 0x02fac398
+    },
+    pubKeyHash: 0x1e,
+    scriptHash: 0x16,
+    wif: 0x9e
+  }
+
+var keyPair = bitcoin.ECPair.fromWIF('6Kq3vjVfdF5TwFBZ9r1yZAPYtKSxotvm45EXjxkwR5p3aNb4DKX', dogecoinNetwork);
+var privateKey = keyPair.__d;
+var message = 'This is an example of a dogecoin signed message.';
+
+var signature = bitcoinMessage.sign(message, privateKey, keyPair.compressed);
+console.log(signature.toString('base64'));
+// => HCo9HyAmfVmLnEfTvsB+kwr+j9LbWV1lOwPKi2OpOaOBOxkOnUTXjx5o2cURRPe88vYHa4AKyVjJLR9zoEB90Rs=
 ```
 
-> verify(message, address, signature[, network.messagePrefix])
+> verify(message, address, signature[, network.messagePrefix]);
 
-Verify a Bitcoin message
+Verify a Dogecoin message
 ``` javascript
-var address = '1HZwkjkeaoZfTSaJxDw6aKkxp45agDiEzN'
-var signature = 'HJLQlDWLyb1Ef8bQKEISzFbDAKctIlaqOpGbrk3YVtRsjmC61lpE5ErkPRUFtDKtx98vHFGUWlFhsh3DiW6N0rE'
-var message = 'This is an example of a signed message.'
+var address = 'DTAbymNwBLCHiCcwD2oToaKX6ZVgUQ2b2g';
 
-console.log(bitcoinMessage.verify(message, address, signature))
+console.log(bitcoinMessage.verify(message, address, signature));
 // => true
 ```
 


### PR DESCRIPTION
var privateKey = keyPair.d.toBuffer(32) does not work and throws an error.
var privateKey = keyPair.__d fixes it.
In addition, example is clearer when using the same signature and address.