### PR TITLE
Fix magicHash() when dealing with UTF-8 messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,14 +59,16 @@ function magicHash (message, messagePrefix) {
   if (!Buffer.isBuffer(messagePrefix)) {
     messagePrefix = Buffer.from(messagePrefix, 'utf8')
   }
-
+  if (!Buffer.isBuffer(message)) {
+    message = Buffer.from(message, 'utf8')
+  }
   const messageVISize = varuint.encodingLength(message.length)
   const buffer = Buffer.allocUnsafe(
     messagePrefix.length + messageVISize + message.length
   )
   messagePrefix.copy(buffer, 0)
   varuint.encode(message.length, buffer, messagePrefix.length)
-  buffer.write(message, messagePrefix.length + messageVISize)
+  message.copy(buffer, messagePrefix.length + messageVISize)
   return hash256(buffer)
 }
 

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -60,9 +60,19 @@
         "magicHash": "f8a5affbef4a3241b19067aa694562f64f513310817297089a8929a930f4f933"
       },
       {
+        "network": "bitcoin",
+        "message": "Virès is Numéris",
+        "magicHash": "af3d51b82a6694d76af5b49401d6f824d66cfce6f96213e606e7da95fe675f25"
+      },
+      {
         "network": "dogecoin",
         "message": "Vires is Numeris",
         "magicHash": "c0963d20d0accd0ea0df6c1020bf85a7e629a40e7b5363f2c3e9dcafd5638f12"
+      },
+      {
+        "network": "dogecoin",
+        "message": "Virès is Numéris",
+        "magicHash": "188eaf871fc659e3dd7503863fcfe051db149eb4dd8fd77ef020f099b7122b75"
       }
     ],
     "sign": [


### PR DESCRIPTION
Hi,

The magicHash() function was not handling UTF8 messages correctly.
Only 7bits ASCII characters were ok.

I 'd be graceful if you could merge this pull request!

Cheers,