### PR TITLE
Support Segwit (including P2SH wrapped) signatures created by Electrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
-## Examples
+## Examples (Note about Electrum support at the bottom)
 
 ``` javascript
 var bitcoin = require('bitcoinjs-lib') // v4.x.x
@@ -54,7 +54,7 @@ console.log(signature.toString('base64'))
 // => 'J9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk='
 ```
 
-> verify(message, address, signature[, network.messagePrefix])
+> verify(message, address, signature[, network.messagePrefix, checkSegwitAlways])
 
 Verify a Bitcoin message
 ``` javascript
@@ -63,5 +63,10 @@ var address = '1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV'
 console.log(bitcoinMessage.verify(message, address, signature))
 // => true
 ```
+
+## About Electrum segwit signature support
+
+- For Signing: Use the non-segwit compressed signing parameters for both segwit types (p2sh-p2wpkh and p2wpkh)
+- For Verifying: Pass the checkSegwitAlways argument as true. (messagePrefix should be set to null to default to Bitcoin messagePrefix)
 
 ## LICENSE [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -113,10 +113,29 @@ function sign (
   )
 }
 
-function verify (message, address, signature, messagePrefix) {
+function segwitRedeemHash (publicKeyHash) {
+  const redeemScript = Buffer.concat([
+    Buffer.from('0014', 'hex'),
+    publicKeyHash
+  ])
+  return hash160(redeemScript)
+}
+
+function decodeBech32 (address) {
+  const result = bech32.decode(address)
+  const data = bech32.fromWords(result.words.slice(1))
+  return Buffer.from(data)
+}
+
+function verify (message, address, signature, messagePrefix, checkSegwitAlways) {
   if (!Buffer.isBuffer(signature)) signature = Buffer.from(signature, 'base64')
 
   const parsed = decodeSignature(signature)
+
+  if (checkSegwitAlways && !parsed.compressed) {
+    throw new Error('checkSegwitAlways can only be used with a compressed pubkey signature flagbyte')
+  }
+
   const hash = magicHash(message, messagePrefix)
   const publicKey = secp256k1.recover(
     hash,
@@ -129,22 +148,31 @@ function verify (message, address, signature, messagePrefix) {
 
   if (parsed.segwitType) {
     if (parsed.segwitType === SEGWIT_TYPES.P2SH_P2WPKH) {
-      const redeemScript = Buffer.concat([
-        Buffer.from('0014', 'hex'),
-        publicKeyHash
-      ])
-      const redeemScriptHash = hash160(redeemScript)
-      actual = redeemScriptHash
+      actual = segwitRedeemHash(publicKeyHash)
       expected = bs58check.decode(address).slice(1)
     } else if (parsed.segwitType === SEGWIT_TYPES.P2WPKH) {
-      const result = bech32.decode(address)
-      const data = bech32.fromWords(result.words.slice(1))
       actual = publicKeyHash
-      expected = Buffer.from(data)
+      expected = decodeBech32(address)
     }
   } else {
-    actual = publicKeyHash
-    expected = bs58check.decode(address).slice(1)
+    if (checkSegwitAlways) {
+      try {
+        expected = decodeBech32(address)
+        // if address is bech32 it is not p2sh
+        return bufferEquals(publicKeyHash, expected)
+      } catch (e) {
+        const redeemHash = segwitRedeemHash(publicKeyHash)
+        expected = bs58check.decode(address).slice(1)
+        // base58 can be p2pkh or p2sh-p2wpkh
+        return (
+          bufferEquals(publicKeyHash, expected) ||
+          bufferEquals(redeemHash, expected)
+        )
+      }
+    } else {
+      actual = publicKeyHash
+      expected = bs58check.decode(address).slice(1)
+    }
   }
 
   return bufferEquals(actual, expected)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-message",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "bitcoinjs-message",
   "keywords": [
     "bitcoinjs-message",


### PR DESCRIPTION
Should resolve the following issues:
* https://github.com/bitcoinjs/bitcoinjs-message/issues/28
* https://github.com/bitcoinjs/bitcoinjs-message/issues/20
* https://github.com/coreyphillips/moonshine/issues/24

Big thanks to @coreyphillips who I saw found the root cause. While I knew it was some offset happening, I was not sure why.

Sponsored by Bity and Relai.