### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export function sign(
   message: string | Buffer,
   privateKey: Buffer,
   compressed?: boolean,
-  sigOptions?: SignatureOptions
+  sigOptions?: SignatureOptions | string
 ): Buffer;
 
 export function verify(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 interface SignatureOptions {
-  segwitType?: string;
+  segwitType?: 'p2wpkh' | 'p2sh(p2wpkh)';
   extraEntropy?: Buffer;
 }
 
@@ -8,11 +8,19 @@ export function magicHash(
   messagePrefix?: string
 ): Buffer;
 
+// sign function is overloaded
 export function sign(
   message: string | Buffer,
   privateKey: Buffer,
   compressed?: boolean,
-  sigOptions?: SignatureOptions | string
+  sigOptions?: SignatureOptions
+): Buffer;
+export function sign(
+  message: string | Buffer,
+  privateKey: Buffer,
+  compressed?: boolean,
+  messagePrefix?: string,
+  sigOptions?: SignatureOptions
 ): Buffer;
 
 export function verify(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-message",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "bitcoinjs-message",
   "keywords": [
     "bitcoinjs-message",


### PR DESCRIPTION
Hello,

I believe there's a slight omission in the type signature of the `sign` function.

The implementation of `function sign` takes a `string` for the `messagePrefix` argument and passes it to the `magicHash` function as the `messagePrefix` argument (which _is_ typed as a string), but this information isn't reflected in the current `.d.ts` file. Currently, the types indicate that the user _must_ pass a `SignatureOptions` type to `sign` as `messagePrefix`, a change made sometime between 2.0.0 and 2.1.3.

Note that if this was really the case, the change in  API from accepting a `string` to only accepting a `SignatureOptions` would likely have been called a breaking change. But, the same code used to work with version 2.0.0 still works with version 2.1.3, except for the types!

Since the code goes out of its way to support backwards compatibility, I believe the types should match.

Note that I have not yet bumped the version number.

Best,
Eric