### PR TITLE
feat: update secp256k1 library to v5.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,10 +127,10 @@ function sign (
   const hash = magicHash(message, messagePrefixArg)
   const sigObj = isSigner(privateKey)
     ? privateKey.sign(hash, extraEntropy)
-    : secp256k1.sign(hash, privateKey, { data: extraEntropy })
+    : secp256k1.ecdsaSign(hash, privateKey, { data: extraEntropy })
   return encodeSignature(
     sigObj.signature,
-    sigObj.recovery,
+    sigObj.recid,
     compressed,
     segwitType
   )
@@ -153,11 +153,11 @@ function signAsync (
     const hash = magicHash(message, messagePrefixArg)
     return isSigner(privateKey)
       ? privateKey.sign(hash, extraEntropy)
-      : secp256k1.sign(hash, privateKey, { data: extraEntropy })
+      : secp256k1.ecdsaSign(hash, privateKey, { data: extraEntropy })
   }).then((sigObj) => {
     return encodeSignature(
       sigObj.signature,
-      sigObj.recovery,
+      sigObj.recid,
       compressed,
       segwitType
     )
@@ -188,12 +188,13 @@ function verify (message, address, signature, messagePrefix, checkSegwitAlways) 
   }
 
   const hash = magicHash(message, messagePrefix)
-  const publicKey = secp256k1.recover(
-    hash,
+  const publicKey = secp256k1.ecdsaRecover(
     parsed.signature,
     parsed.recovery,
+    hash,
     parsed.compressed
   )
+
   const publicKeyHash = hash160(publicKey)
   let actual, expected
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bs58check": "^2.1.2",
     "buffer-equals": "^1.0.3",
     "create-hash": "^1.1.2",
-    "secp256k1": "^3.0.1",
+    "secp256k1": "5.0.0",
     "varuint-bitcoin": "^1.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -27,8 +27,8 @@ fixtures.valid.magicHash.forEach(f => {
 fixtures.valid.sign.forEach(f => {
   test('sign: ' + f.description, async t => {
     const pk = new bitcoin.ECPair(new BigInteger(f.d)).d.toBuffer(32)
-    const signer = (hash, ex) => secp256k1.sign(hash, pk, { data: ex })
-    const signerAsync = async (hash, ex) => secp256k1.sign(hash, pk, { data: ex })
+    const signer = (hash, ex) => secp256k1.ecdsaSign(hash, pk, { data: ex })
+    const signerAsync = async (hash, ex) => secp256k1.ecdsaSign(hash, pk, { data: ex })
     let signature = message.sign(
       f.message,
       pk,


### PR DESCRIPTION
As part of this update there had to be minor changes to the secp256k1 library callsites. sign was changed to ecdsaSign and recover was changed to ecdsaRecover including reordering of params.

Ticket: BTC-421